### PR TITLE
docs: Add overlay documentation from /root/newdocs

### DIFF
--- a/docs/overlays/figma-tokens-overlay/design-tokens/tokens.json
+++ b/docs/overlays/figma-tokens-overlay/design-tokens/tokens.json
@@ -1,0 +1,67 @@
+{
+  "color": {
+    "darkBg": {
+      "value": "#0D0D0D"
+    },
+    "darkGrey": {
+      "value": "#1A1A1A"
+    },
+    "goldAccent": {
+      "value": "#C8A15A"
+    },
+    "neonTurquoise": {
+      "value": "#00E0B8"
+    },
+    "textWhite": {
+      "value": "#F5F5F5"
+    },
+    "textGrey": {
+      "value": "#CCCCCC"
+    }
+  },
+  "font": {
+    "heading": {
+      "value": "Orbitron, Oswald, Rajdhani"
+    },
+    "body": {
+      "value": "Inter, Roboto, IBM Plex Sans"
+    },
+    "microcopy": {
+      "value": "Inter Caps"
+    }
+  },
+  "size": {
+    "h1": {
+      "value": "48px"
+    },
+    "h2": {
+      "value": "32px"
+    },
+    "body": {
+      "value": "16px"
+    },
+    "microcopy": {
+      "value": "12px"
+    }
+  },
+  "effect": {
+    "glowGold": {
+      "value": {
+        "type": "dropShadow",
+        "color": "#C8A15A66",
+        "x": 0,
+        "y": 0,
+        "blur": 8
+      }
+    },
+    "glowNeon": {
+      "value": {
+        "type": "dropShadow",
+        "color": "#00E0B866",
+        "x": 0,
+        "y": 0,
+        "blur": 8
+      }
+    }
+  }
+}

--- a/docs/overlays/figma-tokens-overlay/docs/ui-ux/14_figma_tokens_wireframe.md
+++ b/docs/overlays/figma-tokens-overlay/docs/ui-ux/14_figma_tokens_wireframe.md
@@ -1,0 +1,38 @@
+# Figma Tokens & Wireframe Guide
+
+## 1. File Tokens
+- `design-tokens/tokens.json` chứa toàn bộ **Design Tokens** cho Figma (dùng plugin [Figma Tokens](https://docs.figmatokens.com/)).
+- Import trực tiếp trong plugin để tạo **Color Styles, Text Styles, Effect Styles**.
+
+## 2. Tokens Included
+- **Color**
+  - Dark Bg: #0D0D0D
+  - Dark Grey: #1A1A1A
+  - Gold Accent: #C8A15A
+  - Neon Turquoise: #00E0B8
+  - Text White: #F5F5F5
+  - Text Grey: #CCCCCC
+- **Font**
+  - Heading: Orbitron/Oswald/Rajdhani
+  - Body: Inter/Roboto/IBM Plex Sans
+  - Microcopy: Inter Caps
+- **Size**
+  - H1 48px, H2 32px, Body 16px, Microcopy 12px
+- **Effect**
+  - GlowGold: Shadow #C8A15A66 blur 8px
+  - GlowNeon: Shadow #00E0B866 blur 8px
+
+## 3. Figma Setup
+1. Mở Figma → Plugin → Figma Tokens → Import JSON.
+2. Apply tokens cho Styles (Color, Text, Effect).
+3. Tạo Page `Style Guide`: drag các rectangle/text → apply tokens → preview.
+
+## 4. Wireframe Pages
+- Page 1: Style Tokens
+- Page 2: Components (Header, Footer, ProductCard, Filter, CTA, SpecsTable, ReviewCard)
+- Page 3: Screens (Home, PLP, PDP, Custom)
+
+## 5. Workflow
+- Dev có thể export tokens JSON → sync sang code (Tailwind config, CSS variables).
+- Designer có thể update tokens trong plugin → push lại repo.
+

--- a/docs/overlays/tailwind-config-overlay/docs/ui-ux/15_tailwind_tokens_mapping.md
+++ b/docs/overlays/tailwind-config-overlay/docs/ui-ux/15_tailwind_tokens_mapping.md
@@ -1,0 +1,20 @@
+# Tailwind Config Mapping từ Figma Tokens
+
+## Cấu hình
+- File: `apps/web/tailwind.config.ts`
+- Map trực tiếp từ `design-tokens/tokens.json`:
+  - Colors → theme.colors
+  - Fonts → theme.fontFamily
+  - Sizes → theme.fontSize (h1, h2, body, microcopy)
+  - Effects → theme.boxShadow (glowGold, glowNeon)
+
+## Sử dụng
+- Heading H1: `className="font-heading text-h1 text-goldAccent"`
+- Body: `className="font-body text-body text-textGrey"`
+- Microcopy: `className="font-microcopy text-microcopy tracking-widest"`
+- Button Gold: `bg-goldAccent shadow-glowGold hover:shadow-lg`
+- Button Neon: `bg-neonTurquoise shadow-glowNeon hover:shadow-lg`
+
+## Lợi ích
+- Dev và Designer đồng bộ 100%: Figma Tokens ↔ Tailwind config.
+- Khi update tokens, chỉ cần build lại config từ JSON.

--- a/docs/overlays/tech-industrial-style-overlay/docs/ui-ux/13_style_tech-industrial.md
+++ b/docs/overlays/tech-industrial-style-overlay/docs/ui-ux/13_style_tech-industrial.md
@@ -1,0 +1,100 @@
+# 🎛 B-Audio UI/UX Style Guide
+**Phong cách: Tech-Industrial + DIY**  
+**Ứng dụng:** Website bán loa DIY / Loa kéo / Loa Bluetooth
+
+---
+
+## 1. Concept & Tone
+- **Concept:** kết hợp **công nghiệp hiện đại (Tech-Industrial)** với cảm giác **DIY Workshop**.
+- **Mood:** mạnh mẽ, chắc chắn, có “chất cơ khí” (industrial) nhưng vẫn dễ gần, custom được (DIY).
+- **Trải nghiệm:** khách hàng cảm thấy như đang bước vào xưởng chế tác loa chuyên nghiệp nhưng mở cửa cho mọi người.
+
+---
+
+## 2. Palette màu
+- **Nền:**  
+  - `#0D0D0D` (gần đen, gợi không gian công nghiệp)  
+  - `#1A1A1A` (xám đậm)  
+- **Accent:**  
+  - `#C8A15A` (gold – sang trọng, gợi chi tiết loa cao cấp)  
+  - `#00E0B8` (turquoise neon – nhấn mạnh công nghệ)  
+- **Text:**  
+  - Trắng (`#F5F5F5`) cho heading  
+  - Xám sáng (`#CCCCCC`) cho body  
+- **DIY feel:** thêm chút **texture bê tông / metal brushed** làm background hero.
+
+---
+
+## 3. Typography
+- **Heading (Logo/H1):** Sans-serif công nghiệp, chữ in đậm, **Condensed** (ví dụ: **Orbitron**, **Oswald**, **Rajdhani**).
+- **Body:** font sạch, dễ đọc: **Inter**, **Roboto**, hoặc **IBM Plex Sans**.
+- **Microcopy:** chữ in **all-caps** nhỏ, tracking rộng, tạo cảm giác “tech”.
+
+---
+
+## 4. Layout
+- **Grid:** rõ ràng, chia cột chắc chắn (12 col).
+- **Hero section:** full-width, nền tối, overlay metal/mesh, text neon highlight.
+- **Cards:** bo góc vừa (`lg` hoặc `xl`), viền mảnh màu **accent neon**.
+- **Hover:** chuyển nhẹ sang màu neon hoặc viền sáng (glow effect).
+
+---
+
+## 5. Components
+### Header
+- Logo dạng chữ (wordmark) + icon loa.
+- Menu ngang, chữ all-caps nhỏ.
+- Search bar kiểu tech (border sáng neon).
+
+### Product Card
+- Ảnh loa trên nền tối/kim loại.
+- Tên sản phẩm in đậm, giá highlight vàng.
+- Hover: ảnh shift nhẹ + viền glow.
+
+### PDP (Product Detail Page)
+- Gallery lớn bên trái (background tối).
+- Thông số kỹ thuật trong **Spec Table**: dạng bảng công nghiệp (border neon).
+- Review hiển thị dạng card tối, chữ sáng.
+
+### CTA
+- Nút đậm màu vàng/gold hoặc neon.
+- Hover: glow + transition scale nhẹ.
+
+---
+
+## 6. Hình ảnh & Media
+- Ảnh sản phẩm: chụp trên nền bê tông, gỗ thô, hoặc background xưởng.
+- Ánh sáng hơi “dramatic” (tương phản mạnh).
+- Icon: vector line-based, hơi vuông vức, màu đơn sắc (lucide-react).
+- Video: test âm thanh/quá trình DIY trong xưởng.
+
+---
+
+## 7. Microinteraction
+- Hover glow: vàng hoặc neon.
+- Button click: ripple nhẹ.
+- Loading skeleton: block vuông, xám đậm, shimmer sáng.
+
+---
+
+## 8. UX Flow
+- **Khám phá:** Search + Filter mạnh, so sánh dễ.
+- **Trust:** hiển thị badge “Xưởng thật”, “Custom theo yêu cầu”.
+- **Checkout/Quote:** tối giản, 1–2 bước, form đậm chất tech.
+- **Custom Page:** form có slider (công suất W), color picker (màu thùng loa), upload ảnh tham khảo.
+
+---
+
+## 9. SEO & Content Tone
+- Heading: từ khóa chính + phong cách tech.
+- Content: **ngắn, mạnh, trực diện** → “Loa kéo 500W – Pin 12h – DIY Custom”.
+- FAQ: dạng industrial card accordion.
+
+---
+
+## 10. Demo Keywords cho Designer
+- “Tech-Industrial website”
+- “DIY Workshop aesthetic”
+- “Dark theme + Neon accent”
+- “Metal grid background”
+- “Brushed steel + Glow UI”

--- a/docs/ui-ux/overlays/apps/web/tailwind.config.ts
+++ b/docs/ui-ux/overlays/apps/web/tailwind.config.ts
@@ -1,0 +1,37 @@
+import type { Config } from 'tailwindcss'
+
+const config: Config = {
+  content: [
+    './app/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}',
+  ],
+  theme: {
+    extend: {
+      colors: {
+        darkBg: '#0D0D0D',
+        darkGrey: '#1A1A1A',
+        goldAccent: '#C8A15A',
+        neonTurquoise: '#00E0B8',
+        textWhite: '#F5F5F5',
+        textGrey: '#CCCCCC',
+      },
+      fontFamily: {
+        heading: ['Orbitron', 'Oswald', 'Rajdhani', 'sans-serif'],
+        body: ['Inter', 'Roboto', 'IBM Plex Sans', 'sans-serif'],
+        microcopy: ['Inter', 'sans-serif'],
+      },
+      fontSize: {
+        h1: ['48px', { lineHeight: '1.2', fontWeight: '700' }],
+        h2: ['32px', { lineHeight: '1.3', fontWeight: '600' }],
+        body: ['16px', { lineHeight: '1.6' }],
+        microcopy: ['12px', { letterSpacing: '0.1em', textTransform: 'uppercase' }],
+      },
+      boxShadow: {
+        glowGold: '0 0 8px #C8A15A66',
+        glowNeon: '0 0 8px #00E0B866',
+      },
+    },
+  },
+  plugins: [],
+}
+export default config


### PR DESCRIPTION
- Add figma-tokens-overlay with design tokens and wireframe docs
- Add tailwind-config-overlay with tokens mapping documentation
- Add tech-industrial-style-overlay with styling documentation
- Imported from /root/newdocs and placed in docs/overlays/